### PR TITLE
Added ability to change system-wide locale. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ To install the server
 
 	class {'postgresql::server': }
 
+By default, the system-wide locale is en_GB.UTF-8. If you need to change 
+this (due to that locale not being installed or available):
+
+        class { 'postgresql::server': locale => 'en_US.UTF-8' }
+
 Again, a particular version
 
 	class {'postgresql::server':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,5 @@
 class postgresql::params {
+  $locale = 'en_GB.UTF-8'
   case $::operatingsystem {
     /(Ubuntu|Debian)/: {
       $version = '9.1'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,5 +1,6 @@
 class postgresql::server (
   $server_package = $postgresql::params::server_package,
+  $locale = $postgresql::params::locale,
   $version = $postgresql::params::version,
   $listen = $postgresql::params::listen_address,
   $port = $postgresql::params::port

--- a/templates/postgresql.conf
+++ b/templates/postgresql.conf
@@ -398,7 +398,6 @@ log_line_prefix = '%t '			# special values:
 					#   %q = stop here in non-session
 					#        processes
 					#   %% = '%'
-					# e.g. '<%u%%%d> '
 #log_lock_waits = off			# log lock waits >= deadlock_timeout
 #log_statement = 'none'			# none, ddl, mod, all
 #log_temp_files = -1			# log temporary files equal or larger
@@ -497,11 +496,11 @@ datestyle = 'iso, mdy'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_GB.UTF-8'			# locale for system error message
+lc_messages = '<%= locale %>'			# locale for system error message
 					# strings
-lc_monetary = 'en_GB.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_GB.UTF-8'			# locale for number formatting
-lc_time = 'en_GB.UTF-8'				# locale for time formatting
+lc_monetary = '<%= locale %>'			# locale for monetary formatting
+lc_numeric = '<%= locale %>'			# locale for number formatting
+lc_time = '<%= locale %>'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'


### PR DESCRIPTION
PostgreSQL will not start unless it is either configured with an installed locale or en_GB.UTF-8 is installed specifically.

I also edited postgresql.conf as an unrelated <% was interfering. 
