### PR TITLE
Improved postgresql.conf for dealing with arrays in listener configuration

### DIFF
--- a/templates/postgresql.conf
+++ b/templates/postgresql.conf
@@ -57,7 +57,7 @@ external_pid_file = '/var/run/postgresql/<%= version %>-main.pid'		# write an ex
 # - Connection Settings -
 
 <% if listen.is_a? Array -%>
-listen_addresses = '<% listen.each do |addr| -%><%= "#{addr}," %><% end -%>
+listen_addresses = '<%= listen.join ',' %>'
 <% else %>
 listen_addresses = '<%= listen %>'
 <% end %>


### PR DESCRIPTION
When dealing with an array of listeners the generated result is now as expected by the postgres server.
