### PR TITLE
Don't hardcode a provider for the postgresql server package

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -18,7 +18,6 @@ class postgresql::server (
     ensure      => running,
     hasstatus   => false,
     hasrestart  => true,
-    provider    => 'debian',
     subscribe   => Package["postgresql-server-$version"],
   }
 


### PR DESCRIPTION
Let Puppet determine the proper provider to use.
