### PR TITLE
peer method does not exist in psql 8.4

### DIFF
--- a/templates/pg_hba.conf.erb
+++ b/templates/pg_hba.conf.erb
@@ -82,12 +82,12 @@
 # maintenance (custom daily cronjobs, replication, and similar tasks).
 #
 # Database administrative login by Unix domain socket
-local   all             postgres                                peer
+local   all             postgres                                ident
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
 # "local" is for Unix domain socket connections only
-local   all             all                                     peer
+local   all             all                                     ident
 # IPv4 local connections:
 host    all             all             127.0.0.1/32            md5
 # IPv6 local connections:
@@ -100,6 +100,6 @@ host    all             all             ::1/128                 md5
 
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
-#local   replication     postgres                                peer
+#local   replication     postgres                                ident
 #host    replication     postgres        127.0.0.1/32            md5
 #host    replication     postgres        ::1/128                 md5


### PR DESCRIPTION
If we want to use this same file for both 8.4 and 9.1, we must use a method that exists on both servers.

If not, we must provide some logic that uses "peer" on 9.1 and "ident" on 8.4 servers.
