### PR TITLE
Allow passwordless roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ is a member of.
 		password => 'pgpassword',
 	}
 
+To create users without passwords (such as for peer/ident authentication),
+simply leave off the 'password' key.
+
 You can also modify other attributes like whether the user can create
 databases (`createdb`), create other roles (`createrole`) or is the
 superuser (`superuser`).

--- a/lib/puppet/provider/pg_user/debian_postgresql.rb
+++ b/lib/puppet/provider/pg_user/debian_postgresql.rb
@@ -8,8 +8,12 @@ Puppet::Type.type(:pg_user).provide(:debian_postgresql) do
   optional_commands :su => 'su'
 
   def create
-    stm = "create role %s encrypted password '%s'" % [\
-        @resource.value(:name), @resource.value(:password) ]
+
+    if @resource.value(:password)
+      password_string = " encrypted password '%s'" % @resource.value(:password)
+    end
+
+    stm = "create role %s#{password_string}" % @resource.value(:name)
 
     if @resource.value(:createdb) == true
         stm = stm + " createdb"


### PR DESCRIPTION
Sometimes, you want roles to have no passwords (i.e. for peer or ident authentication modes).
