### PR TITLE
Fix for Could not evaluate: undefined method `each' for "1\n":String on Ruby 1.9 and higher

### DIFF
--- a/lib/puppet/provider/pg_database/debian_postgresql.rb
+++ b/lib/puppet/provider/pg_database/debian_postgresql.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:pg_database).provide(:debian_postgresql) do
   def exists?
     su_output = su("-", "postgres", "-c", "psql --quiet -A -t -c \"select 1 from pg_database where datname = '%s';\"" % @resource.value(:name))
     return false if su_output.length == 0
-    su_output.each do |line|
+    su_output.each_line do |line|
       if line == "1\n"
         return true
       else

--- a/lib/puppet/provider/pg_user/debian_postgresql.rb
+++ b/lib/puppet/provider/pg_user/debian_postgresql.rb
@@ -51,7 +51,7 @@ Puppet::Type.type(:pg_user).provide(:debian_postgresql) do
   def exists?
     su_output = su("-", "postgres", "-c", "psql --quiet -A -t -c \"select 1 from pg_roles where rolname = '%s';\"" % @resource.value(:name))
     return false if su_output.length == 0
-    su_output.each do |line|
+    su_output.each_line do |line|
       if line == "1\n"
         return true
       else


### PR DESCRIPTION
Ruby 1.9 doesn't support each on a String. It is changed to .each_line
