### PR TITLE
Uses proper configuration name in postgresql.conf

### DIFF
--- a/templates/postgresql.conf.erb
+++ b/templates/postgresql.conf.erb
@@ -70,7 +70,12 @@ max_connections = 100			# (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3	# (change requires restart)
+<% if Gem::Version.new(@version) >= Gem::Version.new('9.3') -%>
+unix_socket_directories = '/var/run/postgresql' # comma-separated list of directories
+<% else -%>
 unix_socket_directory = '/var/run/postgresql'		# (change requires restart)
+<% end %>
+
 #unix_socket_group = ''			# (change requires restart)
 #unix_socket_permissions = 0777		# begin with 0 to use octal notation
 					# (change requires restart)

--- a/templates/postgresql.conf.erb
+++ b/templates/postgresql.conf.erb
@@ -70,7 +70,8 @@ max_connections = 100			# (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3	# (change requires restart)
-<% if Gem::Version.new(@version) >= Gem::Version.new('9.3') -%>
+<% parts = @version.split '.' %>
+<% if parts.shift.to_i >= 9 and parts.shift.to_i >= 3 -%>
 unix_socket_directories = '/var/run/postgresql' # comma-separated list of directories
 <% else -%>
 unix_socket_directory = '/var/run/postgresql'		# (change requires restart)


### PR DESCRIPTION
Requires Ruby 1.9 or higher

Possible fix for #21
